### PR TITLE
Potential fix for code scanning alert no. 2: Open URL redirect

### DIFF
--- a/core/corehttp/gateway_handler.go
+++ b/core/corehttp/gateway_handler.go
@@ -10,7 +10,7 @@ import (
 	"net/textproto"
 	"net/url"
 	"os"
-	gopath "path"
+
 	"regexp"
 	"runtime/debug"
 	"strings"
@@ -975,6 +975,9 @@ func handleUnsupportedHeaders(r *http.Request) (err *requestError) {
 // TLDR: redirect /ipfs/?uri=ipfs%3A%2F%2Fcid%3Fquery%3Dval to /ipfs/cid?query=val
 func handleProtocolHandlerRedirect(w http.ResponseWriter, r *http.Request, logger *zap.SugaredLogger) (requestHandled bool) {
 	if uriParam := r.URL.Query().Get("uri"); uriParam != "" {
+		// Some user agents treat backslashes as forward slashes; normalize before parsing.
+		uriParam = strings.ReplaceAll(uriParam, "\\", "/")
+
 		u, err := url.Parse(uriParam)
 		if err != nil {
 			webError(w, "failed to parse uri query parameter", err, http.StatusBadRequest)
@@ -984,12 +987,25 @@ func handleProtocolHandlerRedirect(w http.ResponseWriter, r *http.Request, logge
 			webError(w, "uri query parameter scheme must be ipfs or ipns", err, http.StatusBadRequest)
 			return true
 		}
-		path := u.Path
-		if u.RawQuery != "" { // preserve query if present
-			path = path + "?" + u.RawQuery
+		if u.Host == "" || strings.Contains(u.Host, "/") || strings.Contains(u.Host, "\\") {
+			webError(w, "uri query parameter must include a valid content identifier", fmt.Errorf("invalid host in uri query parameter"), http.StatusBadRequest)
+			return true
 		}
 
-		redirectURL := gopath.Join("/", u.Scheme, u.Host, path)
+		cleanPath := u.Path
+		if strings.HasPrefix(cleanPath, "//") {
+			webError(w, "uri query parameter contains invalid path", fmt.Errorf("invalid path in uri query parameter"), http.StatusBadRequest)
+			return true
+		}
+		if cleanPath == "" {
+			cleanPath = "/"
+		}
+
+		redirectURL := "/" + u.Scheme + "/" + u.Host + cleanPath
+		if u.RawQuery != "" { // preserve query if present
+			redirectURL = redirectURL + "?" + u.RawQuery
+		}
+
 		logger.Debugw("uri param, redirect", "to", redirectURL, "status", http.StatusMovedPermanently)
 		http.Redirect(w, r, redirectURL, http.StatusMovedPermanently)
 		return true


### PR DESCRIPTION
Potential fix for [https://github.com/Rose2161/go-ipfs/security/code-scanning/2](https://github.com/Rose2161/go-ipfs/security/code-scanning/2)

To fix open-redirect risk, ensure the redirect target is always a validated local path (never scheme-relative, absolute external URL, or malformed).  
Best fix in `core/corehttp/gateway_handler.go` within `handleProtocolHandlerRedirect`:

- Normalize browser-ambiguous backslashes before parsing (`strings.ReplaceAll(uriParam, "\\", "/")`).
- Parse and validate:
  - scheme must be `ipfs` or `ipns` (already present),
  - `u.Host` must be non-empty and must not contain `/` or `\`,
  - `u.Path` must not start with `//` (prevents scheme-relative surprises).
- Build redirect as a local path with explicit concatenation:
  - `"/" + u.Scheme + "/" + u.Host + cleanedPath`
  - append query if present.
- Keep behavior/functionality: still redirects protocol-handler URIs to gateway paths with query preserved.

No new dependencies are needed; `strings` and `net/url` are already imported.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
